### PR TITLE
Organize standalone pages under pages directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           <span class="nav-bubble"><i data-lucide="home"></i></span>
           <span>Home</span>
         </a>
-        <a href="leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
+        <a href="pages/leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
           <span class="nav-bubble"><i data-lucide="trophy"></i></span>
           <span>Leaderboards</span>
         </a>
@@ -100,7 +100,7 @@
           <p class="mt-5 text-white/70 max-w-2xl mx-auto">Welcome to TRUE Rewards designed by a TRUE Player. Leaderboards, Challenges and an Active Community for all things Casino.</p>
 
           <div class="mt-8 flex items-center justify-center gap-4">
-            <a href="leaderboard.html" class="magnetic rounded-2xl px-6 py-3 font-semibold text-sm bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink inline-flex items-center gap-2">
+            <a href="pages/leaderboard.html" class="magnetic rounded-2xl px-6 py-3 font-semibold text-sm bg-gradient-to-br from-pink-brand to-blue-brand hover:drop-shadow-neonPink inline-flex items-center gap-2">
               <i data-lucide="trophy" class="w-5 h-5"></i> Leaderboards
             </a>
             <a href="#events" class="magnetic rounded-2xl px-6 py-3 font-semibold text-sm bg-gradient-to-br from-indigo to-violet hover:drop-shadow-neon inline-flex items-center gap-2">
@@ -159,7 +159,7 @@
 
           <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             <!-- Leaderboards -->
-            <a id="leaderboards" href="leaderboard.html" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
+            <a id="leaderboards" href="pages/leaderboard.html" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
               <div class="relative flex items-center gap-3">
                 <div class="w-12 h-12 rounded-2xl grid place-items-center"><i data-lucide="trophy" class="w-6 h-6"></i></div>
                 <div>
@@ -173,7 +173,7 @@
             </a>
 
             <!-- Bonuses -->
-            <a id="bonuses" href="/bonuses" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
+            <a id="bonuses" href="pages/bonuses.html" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
               <div class="relative flex items-center gap-3">
                 <div class="w-12 h-12 rounded-2xl grid place-items-center"><i data-lucide="gift" class="w-6 h-6"></i></div>
                 <div>
@@ -187,7 +187,7 @@
             </a>
 
             <!-- Rewards -->
-            <a id="rewards" href="/rewards" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
+            <a id="rewards" href="pages/rewards.html" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
               <div class="relative flex items-center gap-3">
                 <div class="w-12 h-12 rounded-2xl grid place-items-center"><i data-lucide="coins" class="w-6 h-6"></i></div>
                 <div>
@@ -215,7 +215,7 @@
             </a>
 
             <!-- Content -->
-            <a id="content" href="/content" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
+            <a id="content" href="pages/content.html" class="group relative rounded-3xl p-5 glass transition overflow-hidden tilt">
               <div class="relative flex items-center gap-3">
                 <div class="w-12 h-12 rounded-2xl grid place-items-center"><i data-lucide="video" class="w-6 h-6"></i></div>
                 <div>
@@ -245,11 +245,11 @@
         <div class="grid grid-cols-2 gap-6 text-sm">
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Pages</div>
-            <a class="block hover:text-white/90" href="/leaderboards">Leaderboards</a>
-            <a class="block hover:text-white/90" href="/bonuses">Bonuses</a>
-            <a class="block hover:text-white/90" href="/rewards">Rewards</a>
+            <a class="block hover:text-white/90" href="pages/leaderboard.html">Leaderboards</a>
+            <a class="block hover:text-white/90" href="pages/bonuses.html">Bonuses</a>
+            <a class="block hover:text-white/90" href="pages/rewards.html">Rewards</a>
             <a class="block hover:text-white/90" href="/events">Events</a>
-            <a class="block hover:text-white/90" href="/content">Content</a>
+            <a class="block hover:text-white/90" href="pages/content.html">Content</a>
           </div>
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Company</div>

--- a/pages/bonuses.html
+++ b/pages/bonuses.html
@@ -10,11 +10,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="assets/styles/main.css">
+    <link rel="stylesheet" href="../assets/styles/main.css">
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="assets/scripts/main.js"></script>
+    <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
     <script defer src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
@@ -32,22 +32,22 @@
     <!-- Sidebar (same as new theme) -->
     <aside class="nav-rail fixed left-0 top-0 h-full z-20">
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
-        <a href="/" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
+        <a href="../index.html" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
   <span class="nav-bubble"><i data-lucide="home"></i></span>
   <span class="nav-label">Home</span>
 </a>
 
-<a href="leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
+<a href="../pages/leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
   <span class="nav-bubble"><i data-lucide="trophy"></i></span>
   <span class="nav-label">Leaderboards</span>
 </a>
 
-<a href="/bonuses" class="nav-item is-active" aria-label="Bonuses" style="--accent:#EC4899">
+<a href="../pages/bonuses.html" class="nav-item is-active" aria-label="Bonuses" style="--accent:#EC4899">
   <span class="nav-bubble"><i data-lucide="gift"></i></span>
   <span class="nav-label">Bonuses</span>
 </a>
 
-<a href="/rewards" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
+<a href="../pages/rewards.html" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
   <span class="nav-bubble"><i data-lucide="coins"></i></span>
   <span class="nav-label">Rewards</span>
 </a>
@@ -57,7 +57,7 @@
   <span class="nav-label">Events</span>
 </a>
 
-<a href="/content" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
+<a href="../pages/content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
   <span class="nav-bubble"><i data-lucide="video"></i></span>
   <span class="nav-label">Content</span>
 </a>
@@ -74,7 +74,7 @@
       <div class="max-w-7xl mx-auto flex items-center justify-between p-4">
         <div class="flex items-center gap-3">
           <div class="w-28 h-28 rounded-2xl grid place-items-center overflow-hidden">
-            <img src="assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
+            <img src="../assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
           </div>
         </div>
         <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
@@ -96,7 +96,7 @@
         <!-- Main bonus card -->
         <div class="mt-10 grid lg:grid-cols-[380px,1fr] gap-6 items-stretch">
           <div class="glass rounded-3xl p-4 flex items-center justify-center shadow-card">
-            <img src="assets/images/bonus.png" alt="Main Bonus" class="rounded-2xl w-full h-full object-contain"/>
+            <img src="../assets/images/bonus.png" alt="Main Bonus" class="rounded-2xl w-full h-full object-contain"/>
           </div>
 
           <div class="glass rounded-3xl p-6 sm:p-8 shadow-card">
@@ -195,11 +195,11 @@
         <div class="grid grid-cols-2 gap-6 text-sm">
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Pages</div>
-            <a class="block hover:text-white/90" href="/leaderboards">Leaderboards</a>
-            <a class="block hover:text-white/90" href="/bonuses">Bonuses</a>
-            <a class="block hover:text-white/90" href="/rewards">Rewards</a>
+            <a class="block hover:text-white/90" href="../pages/leaderboard.html">Leaderboards</a>
+            <a class="block hover:text-white/90" href="../pages/bonuses.html">Bonuses</a>
+            <a class="block hover:text-white/90" href="../pages/rewards.html">Rewards</a>
             <a class="block hover:text-white/90" href="/events">Events</a>
-            <a class="block hover:text-white/90" href="/content">Content</a>
+            <a class="block hover:text-white/90" href="../pages/content.html">Content</a>
           </div>
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Company</div>

--- a/pages/content.html
+++ b/pages/content.html
@@ -10,11 +10,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="assets/styles/main.css">
+    <link rel="stylesheet" href="../assets/styles/main.css">
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="assets/scripts/main.js"></script>
+    <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons -->
     <script defer src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
@@ -34,19 +34,19 @@
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
 
-        <a href="/" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
+        <a href="../index.html" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
           <span class="nav-bubble"><i data-lucide="home"></i></span>
           <span class="nav-label">Home</span>
         </a>
-        <a href="/leaderboard" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
+        <a href="../pages/leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
           <span class="nav-bubble"><i data-lucide="trophy"></i></span>
           <span class="nav-label">Leaderboards</span>
         </a>
-        <a href="/bonuses" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
+        <a href="../pages/bonuses.html" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
           <span class="nav-bubble"><i data-lucide="gift"></i></span>
           <span class="nav-label">Bonuses</span>
         </a>
-        <a href="/rewards" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
+        <a href="../pages/rewards.html" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
@@ -54,7 +54,7 @@
           <span class="nav-bubble"><i data-lucide="calendar"></i></span>
           <span class="nav-label">Events</span>
         </a>
-        <a href="/content" class="nav-item is-active" aria-label="Content" style="--accent:#22D3EE">
+        <a href="../pages/content.html" class="nav-item is-active" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
         </a>
@@ -70,7 +70,7 @@
       <div class="max-w-7xl mx-auto flex items-center justify-between p-4">
         <div class="flex items-center gap-3">
           <div class="w-28 h-28 rounded-2xl grid place-items-center overflow-hidden">
-            <img src="assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
+            <img src="../assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
           </div>
         </div>
         <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
@@ -242,11 +242,11 @@
         <div class="grid grid-cols-2 gap-6 text-sm">
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Pages</div>
-            <a class="block hover:text-white/90" href="/leaderboard">Leaderboards</a>
-            <a class="block hover:text-white/90" href="/bonuses">Bonuses</a>
-            <a class="block hover:text-white/90" href="/rewards">Rewards</a>
+            <a class="block hover:text-white/90" href="../pages/leaderboard.html">Leaderboards</a>
+            <a class="block hover:text-white/90" href="../pages/bonuses.html">Bonuses</a>
+            <a class="block hover:text-white/90" href="../pages/rewards.html">Rewards</a>
             <a class="block hover:text-white/90" href="/events">Events</a>
-            <a class="block hover:text-white/90" href="/content">Content</a>
+            <a class="block hover:text-white/90" href="../pages/content.html">Content</a>
           </div>
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Company</div>

--- a/pages/leaderboard.html
+++ b/pages/leaderboard.html
@@ -10,11 +10,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="assets/styles/main.css">
+    <link rel="stylesheet" href="../assets/styles/main.css">
 
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="assets/scripts/main.js"></script>
+    <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide icons (UMD) -->
     <script defer src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
@@ -30,7 +30,7 @@
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
 
-        <a href="/" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
+        <a href="../index.html" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
           <span class="nav-bubble"><i data-lucide="home"></i></span>
           <span class="nav-label">Home</span>
         </a>
@@ -38,11 +38,11 @@
           <span class="nav-bubble"><i data-lucide="trophy"></i></span>
           <span class="nav-label">Leaderboards</span>
         </a>
-        <a href="/bonuses" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
+        <a href="../pages/bonuses.html" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
           <span class="nav-bubble"><i data-lucide="gift"></i></span>
           <span class="nav-label">Bonuses</span>
         </a>
-        <a href="/rewards" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
+        <a href="../pages/rewards.html" class="nav-item" aria-label="Rewards" style="--accent:#FBBF24">
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
@@ -50,7 +50,7 @@
           <span class="nav-bubble"><i data-lucide="calendar"></i></span>
           <span class="nav-label">Events</span>
         </a>
-        <a href="/content" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
+        <a href="../pages/content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
         </a>
@@ -67,7 +67,7 @@
       <div class="max-w-7xl mx-auto flex items-center justify-between p-4">
         <div class="flex items-center gap-3">
           <div class="w-28 h-28 rounded-2xl grid place-items-center overflow-hidden">
-            <img src="assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
+            <img src="../assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
           </div>
         </div>
         <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-8 py-3 text-sm font-medium bg-discord hover:bg-discordDark transition-colors">
@@ -317,11 +317,11 @@
         <div class="grid grid-cols-2 gap-6 text-sm">
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Pages</div>
-            <a class="block hover:text-white/90" href="/leaderboards">Leaderboards</a>
-            <a class="block hover:text-white/90" href="/bonuses">Bonuses</a>
-            <a class="block hover:text-white/90" href="/rewards">Rewards</a>
+            <a class="block hover:text-white/90" href="../pages/leaderboard.html">Leaderboards</a>
+            <a class="block hover:text-white/90" href="../pages/bonuses.html">Bonuses</a>
+            <a class="block hover:text-white/90" href="../pages/rewards.html">Rewards</a>
             <a class="block hover:text-white/90" href="/events">Events</a>
-            <a class="block hover:text-white/90" href="/content">Content</a>
+            <a class="block hover:text-white/90" href="../pages/content.html">Content</a>
           </div>
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Company</div>

--- a/pages/rewards.html
+++ b/pages/rewards.html
@@ -10,11 +10,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="assets/styles/main.css">
+    <link rel="stylesheet" href="../assets/styles/main.css">
 
     <!-- Tailwind -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="assets/scripts/main.js"></script>
+    <script src="../assets/scripts/main.js"></script>
 
     <!-- Lucide -->
     <script defer src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
@@ -29,19 +29,19 @@
       <div class="rail glass h-full flex flex-col items-center pt-6 gap-2 overflow-hidden relative">
         <span class="rail-active pointer-events-none"></span>
 
-        <a href="/" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
+        <a href="../index.html" class="nav-item" aria-label="Home" style="--accent:#60A5FA">
           <span class="nav-bubble"><i data-lucide="home"></i></span>
           <span class="nav-label">Home</span>
         </a>
-        <a href="/leaderboard" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
+        <a href="../pages/leaderboard.html" class="nav-item" aria-label="Leaderboards" style="--accent:#F59E0B">
           <span class="nav-bubble"><i data-lucide="trophy"></i></span>
           <span class="nav-label">Leaderboards</span>
         </a>
-        <a href="/bonuses" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
+        <a href="../pages/bonuses.html" class="nav-item" aria-label="Bonuses" style="--accent:#EC4899">
           <span class="nav-bubble"><i data-lucide="gift"></i></span>
           <span class="nav-label">Bonuses</span>
         </a>
-        <a href="/rewards" class="nav-item is-active" aria-label="Rewards" style="--accent:#FBBF24">
+        <a href="../pages/rewards.html" class="nav-item is-active" aria-label="Rewards" style="--accent:#FBBF24">
           <span class="nav-bubble"><i data-lucide="coins"></i></span>
           <span class="nav-label">Rewards</span>
         </a>
@@ -49,7 +49,7 @@
           <span class="nav-bubble"><i data-lucide="calendar"></i></span>
           <span class="nav-label">Events</span>
         </a>
-        <a href="/content" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
+        <a href="../pages/content.html" class="nav-item" aria-label="Content" style="--accent:#22D3EE">
           <span class="nav-bubble"><i data-lucide="video"></i></span>
           <span class="nav-label">Content</span>
         </a>
@@ -65,7 +65,7 @@
       <div class="max-w-7xl mx-auto flex items-center justify-between p-4">
         <div class="flex items-center gap-3">
           <div class="w-28 h-28 rounded-2xl grid place-items-center overflow-hidden">
-            <img src="assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
+            <img src="../assets/images/word.png" alt="TxPlays Logo" class="w-30 h-30 object-contain">
           </div>
         </div>
         <a href="#discord-login" class="magnetic group relative inline-flex items-center gap-2 rounded-xl px-6 py-3 text-lg font-semibold bg-discord hover:bg-discordDark transition-colors">
@@ -81,7 +81,7 @@
     <!-- HERO: behind heading + cards -->
     <div class="absolute inset-0 -z-10 pointer-events-none">
       <!-- swap background.png for your sun image -->
-      <div class="hero-sun" style="--hero-img: url('assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
+      <div class="hero-sun" style="--hero-img: url('../assets/images/background.png'); --sun-size: min(1200px,95vw)"></div>
       <div class="hero-fade"></div>
     </div>
 
@@ -135,11 +135,11 @@
         <div class="grid grid-cols-2 gap-6 text-sm">
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Pages</div>
-            <a class="block hover:text-white/90" href="/leaderboard">Leaderboards</a>
-            <a class="block hover:text-white/90" href="/bonuses">Bonuses</a>
-            <a class="block hover:text-white/90" href="/rewards">Rewards</a>
+            <a class="block hover:text-white/90" href="../pages/leaderboard.html">Leaderboards</a>
+            <a class="block hover:text-white/90" href="../pages/bonuses.html">Bonuses</a>
+            <a class="block hover:text-white/90" href="../pages/rewards.html">Rewards</a>
             <a class="block hover:text-white/90" href="/events">Events</a>
-            <a class="block hover:text-white/90" href="/content">Content</a>
+            <a class="block hover:text-white/90" href="../pages/content.html">Content</a>
           </div>
           <div class="space-y-2">
             <div class="text-white/60 uppercase tracking-wide text-xs">Company</div>


### PR DESCRIPTION
## Summary
- move the leaderboard, rewards, bonuses, and content HTML documents into a new `pages/` folder and update their asset references for the nested location
- update navigation and footer links across the site to reference `pages/<file>.html`

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9730ea7448332ae2f740cc6f4ad48